### PR TITLE
chore: bootstrap product, architecture, agent specialization

### DIFF
--- a/.claude/PROJECT.md
+++ b/.claude/PROJECT.md
@@ -1,0 +1,29 @@
+# Project Configuration
+
+## Platform
+
+- **Hosting**: gcp
+- **Compute**: Cloud Run
+- **Container Registry**: Artifact Registry
+- **Database**: Neon (serverless Postgres with per-PR branching)
+- **Secrets**: Google Secret Manager
+- **Auth (CI/CD → GCP)**: Workload Identity Federation
+- **Selected**: 2026-05-01
+
+## Stack
+
+- **Runtime**: Python 3.12
+- **Web**: FastAPI + Uvicorn
+- **Templates**: Jinja2 + HTMX 2.x (no JS build step)
+- **Styling**: Pico.css via CDN
+- **DB layer**: SQLModel + Alembic
+- **Package manager**: uv
+
+## Key Service Choices
+
+- **LLM provider**: Anthropic Claude (Opus for quality drafts; Haiku for
+  iteration / cheaper regen) — accessed via the Anthropic Python SDK.
+- **User auth**: Email magic-link only (no passwords).
+- **Email sender**: Resend (default; free tier covers MVP user volume).
+- **Observability**: Google Cloud Logging + Error Reporting (zero-setup,
+  GCP-native).

--- a/.claude/agents/github-ticket-worker.md
+++ b/.claude/agents/github-ticket-worker.md
@@ -30,15 +30,34 @@ You are a Senior Full-Stack Engineer. Your primary responsibility is to autonomo
 
 ## Project Context
 
-<!--
-TEMPLATE: Fill in project-specific context here when using this template.
-
-Example fields to populate:
-- **Platform(s)**: [Web, Mobile, Desktop, etc.]
-- **Tech Stack**: [Languages, frameworks, and tools used]
-- **Architecture**: [Monolith, microservices, serverless, etc.]
-- **Key Quality Standards**: [Performance, accessibility, security requirements]
--->
+- **Product**: A D&D character builder. Users describe a character in
+  natural language; the app generates stats, personality, and lore.
+  Per-user "projects" are workspaces, one per character.
+  See `docs/PRODUCT-REQUIREMENTS.md`.
+- **Platform**: Web application only (server-rendered HTML; no SPA).
+- **Tech Stack**:
+  - Python 3.12, FastAPI + Uvicorn
+  - Jinja2 templates + HTMX 2.x (no JS build step), Pico.css via CDN
+  - SQLModel + Alembic
+  - Anthropic Python SDK (Claude Opus / Haiku) for generation
+  - Resend Python SDK for magic-link email
+  - `uv` as the package manager
+- **Architecture**: Modular monolith on Google Cloud Run with Neon
+  Postgres (per-PR DB branches). Single deployable, organized by
+  feature module (`auth/`, `projects/`, `characters/`). See
+  `docs/TECHNICAL-ARCHITECTURE.md`.
+- **Key Quality Standards**:
+  - Authorization: every query filtered by `current_user.id` —
+    cross-tenant leaks are P0
+  - LLM call isolation: keep Anthropic calls inside
+    `app/characters/generator.py`; never sprinkle them across modules
+  - HTMX fragment routes return fragments only — assert
+    `"<html" not in response.text` in tests
+  - No real Anthropic / Resend calls in unit tests; inject fakes via
+    `app.dependency_overrides`
+  - All secrets in Google Secret Manager; never commit env files
+  - Use `window.location.origin` (client) or request headers (server)
+    for self-referential URLs — never hardcode app URLs
 
 ## Tools and Capabilities
 
@@ -133,28 +152,55 @@ ask the user to run `gh auth login` (solo) or
 
 ### 3. Implementation Standards
 
-You must strictly adhere to the project's architecture and coding standards defined in `CLAUDE.md`.
+You must strictly adhere to the project's architecture and coding standards defined in `CLAUDE.md` and `docs/TECHNICAL-ARCHITECTURE.md`.
 
-<!--
-TEMPLATE: Fill in project-specific implementation standards here.
-
-Example sections:
 **Technology Stack:**
-- [Language and version]
-- [Framework]
-- [Build tooling]
-- [Testing framework]
+- Python 3.12 (managed with `uv`)
+- FastAPI + Uvicorn for the web layer
+- Jinja2 + HTMX 2.x for the UI (server-rendered; no JS build)
+- SQLModel + Alembic for the database layer
+- pytest + httpx + `fastapi.testclient.TestClient` for tests
+- ruff (lint + format) and mypy (types)
+
+**Module Layout** (extend, do not flatten):
+```
+app/
+  auth/         projects/      characters/    api/
+  models/       db.py          config.py      main.py
+templates/      _fragments/    # HTMX partials
+```
 
 **Code Quality:**
-- [Type safety requirements]
-- [Code style guidelines]
-- [Documentation standards]
+- ruff lint rules: `E,F,I,W,B,UP` (line length 100)
+- `mypy app/` clean — `check_untyped_defs = true`
+- `snake_case` modules/functions; `PascalCase` SQLModel/Pydantic classes
+- Route paths kebab-case (`/auth/verify`, `/projects/{id}`)
+- Module docstring on each new feature module; one-line docstring on
+  each route handler describing what it returns (full page vs fragment)
+- Default to no comments; only add when the *why* is non-obvious
+
+**Database / Migrations:**
+- Schema changes via Alembic: `uv run alembic revision --autogenerate -m "msg"`
+- Per-PR Neon branch runs `alembic upgrade head` automatically — verify
+  CI green before requesting review
+- `Character.data` is JSONB by design; do not migrate it to columns
+  without an ADR
+
+**LLM Discipline:**
+- All Anthropic calls live in `app/characters/generator.py`; do not
+  call the SDK from routes or other modules
+- Cap output tokens per generation — runaway prompts blow the budget
+- Never call the real Anthropic / Resend APIs from unit tests; inject
+  fakes via `app.dependency_overrides`
 
 **Testing Requirements:**
-- [Test types required]
-- [Coverage thresholds]
-- [Pre-commit checks]
--->
+- Unit + HTTP tests with in-memory SQLite (`StaticPool` fixture)
+- Override `get_session` via `app.dependency_overrides`
+- HTMX fragment endpoints: assert HTML substrings AND
+  `assert "<html" not in response.text`
+- Coverage target: 80%+ on `app/` (excluding `app/main.py`)
+- Pre-push hook runs lint + tests automatically. **`--no-verify` is
+  forbidden.** Fix the failing check; do not bypass it.
 
 ### 4. Pull Request Creation
 

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -49,14 +49,21 @@ You are a Staff Engineer and Tech Lead responsible for maintaining the highest q
 
 ## Project Context
 
-<!--
-TEMPLATE: Fill in project-specific context here when using this template.
-
-Example fields to populate:
-- **Platform(s)**: [Web, Mobile, Desktop, etc.]
-- **Tech Stack**: [Languages, frameworks, and tools used]
-- **Quality Standards**: [Performance, accessibility, security requirements]
--->
+- **Product**: D&D character builder. Prompt-driven, lore-consistent
+  character generation. See `docs/PRODUCT-REQUIREMENTS.md`.
+- **Platform**: Web only (FastAPI server-rendered Jinja2 + HTMX).
+- **Tech Stack**: Python 3.12, FastAPI, Jinja2 + HTMX 2.x, SQLModel +
+  Alembic, Anthropic SDK, Resend SDK, `uv`, ruff + mypy, pytest +
+  httpx. Deployed to GCP Cloud Run + Neon Postgres.
+  See `docs/TECHNICAL-ARCHITECTURE.md`.
+- **Quality Standards**:
+  - Authorization scoping: every query filters by `current_user.id`
+  - LLM calls only inside `app/characters/generator.py`
+  - HTMX fragment endpoints return fragments only (not full pages)
+  - No real Anthropic / Resend calls in unit tests
+  - Secrets only in Google Secret Manager
+  - Self-referential URLs use request headers / `window.location.origin`,
+    never hardcoded
 
 Your reviews must ensure that code is:
 - Technically correct and follows best practices
@@ -144,22 +151,49 @@ Conduct thorough technical reviews of PRs linked to issues in the 'In Review' co
 
 ### 2. Architecture Compliance
 
-Ensure changes align with standards in `CLAUDE.md`.
+Ensure changes align with standards in `CLAUDE.md` and
+`docs/TECHNICAL-ARCHITECTURE.md`.
 
-<!--
-TEMPLATE: Fill in project-specific architecture compliance checks here.
-
-Example sections:
 **Technology Stack Compliance:**
-- [Language/framework version requirements]
-- [Build configuration]
-- [Testing patterns]
+- Python 3.12; managed via `uv` (no `pip install` in PRs)
+- `pyproject.toml` for deps; lockfile updated when deps change
+- ruff lint clean (`E,F,I,W,B,UP`); ruff-formatted; mypy clean
+- FastAPI route style: dependency-injected `Session`, typed Pydantic
+  / SQLModel response objects
+- HTMX endpoints: fragment templates from `templates/_fragments/`;
+  full-page templates only on GET routes that return whole pages
 
 **Code Organization:**
-- [Directory structure]
-- [Module organization]
-- [Test file location]
--->
+- Feature-aligned modules under `app/` (`auth/`, `projects/`,
+  `characters/`, `api/`, `models/`); reject cross-module reach-arounds
+- LLM calls live ONLY in `app/characters/generator.py` — flag any
+  Anthropic SDK import outside this file
+- Email sending lives ONLY in `app/auth/email.py`
+- Tests mirror app layout under `tests/`; smoke tests in
+  `tests/smoke/` (gated on `RUN_SMOKE_TESTS=1`)
+- Alembic migrations in `alembic/versions/`; one migration per PR
+  that changes schema; migration name reflects the change
+
+**Critical Review Checks (block on any of these):**
+- Missing `current_user.id` filter on a Project / Character /
+  Generation query → **P0 authorization gap**
+- Real Anthropic / Resend API call in a unit test → **P0**
+- HTMX fragment endpoint returning a full page → **P0**
+- New environment variable not added to `.env.example` AND
+  Secret Manager (staging + prod) → **P0**
+- Hardcoded application URL → **P0** (use request headers /
+  `window.location.origin`)
+- Magic-link token verification missing TTL or single-use nonce
+  rotation → **P0**
+- Token-cap missing on a new Anthropic call site → **P0** (budget)
+- `--no-verify` used to push, or pre-push hook bypassed → **P0**
+
+**Quality Checks:**
+- Coverage holds at ≥80% on `app/` (excluding `app/main.py`)
+- For LLM-touching PRs: PR description includes before/after sample
+  generations
+- New ADR added for significant architectural changes (data model
+  shape, LLM provider, deployment topology)
 
 ### 3. Approval Decision Criteria
 

--- a/.claude/agents/quality-engineer.md
+++ b/.claude/agents/quality-engineer.md
@@ -151,19 +151,54 @@ You are a master of:
 
 ## Project-Specific Context
 
-<!--
-TEMPLATE: Fill in project-specific testing context here when using this template.
-
-Example fields to populate:
-- **Architecture**: [Description of the application architecture]
-- **Testing Stack**: [Testing frameworks and tools used]
-- **Key Test Areas**: [Core areas requiring testing]
-- **Critical Quality Concerns**: [Project-specific quality priorities]
--->
+- **Product**: A D&D character builder. Core value is generating
+  believable, lore-consistent characters from a natural-language prompt.
+  Quality of *generated content* is as load-bearing as code correctness.
+- **Architecture**: Modular monolith. FastAPI + Jinja2 + HTMX,
+  SQLModel + Alembic, deployed to Google Cloud Run with Neon Postgres
+  (per-PR DB branches). See `docs/TECHNICAL-ARCHITECTURE.md`.
+- **Testing Stack**:
+  - `pytest` + `pytest-asyncio` for unit + integration tests
+  - `httpx` + `fastapi.testclient.TestClient` for HTTP tests
+  - In-memory SQLite via `StaticPool` fixture; override
+    `get_session` with `app.dependency_overrides`
+  - `pytest --cov=app --cov-report=term-missing` for coverage
+  - Real Anthropic / Resend calls are **forbidden in unit tests** —
+    inject fakes via `dependency_overrides`. Real-API smoke tests live
+    in `tests/smoke/` and are gated on `RUN_SMOKE_TESTS=1`.
+- **Key Test Areas**:
+  - Magic-link auth: token signing/verification, TTL expiry,
+    single-use nonce rotation, session cookie attributes
+    (HTTP-only, Secure, SameSite=Lax)
+  - Project CRUD with `current_user` scoping (a user must never see
+    another user's projects/characters)
+  - Character generator: parse / validate the structured Anthropic
+    output into the `Character` Pydantic schema; `validator.py`
+    rules-sanity checks on stat blocks
+  - HTMX endpoints: assert HTML substrings AND assert
+    `"<html" not in response.text` for fragment routes (catches
+    full-page leaks)
+  - Alembic migrations run cleanly forward on each PR's Neon branch
+- **Critical Quality Concerns**:
+  - **Authorization scoping**: every query must filter by
+    `current_user.id`. A missing filter is a P0.
+  - **LLM cost**: validate token caps in tests; alert on prompts that
+    exceed budget per generation.
+  - **Generation quality**: include before/after sample generations in
+    PRs that touch prompts. Qualitative review is part of the test
+    plan, not an afterthought.
+  - **Rules accuracy**: generated stat blocks must pass
+    `validator.py`. Failures should mark the character as "draft —
+    verify before play" rather than silently render.
+  - **Email deliverability**: magic-link auth depends on Resend; treat
+    delivery failures as a critical user-facing path.
+  - **Secrets**: no API keys in repo, env files, or test fixtures.
+    Tests must run without `ANTHROPIC_API_KEY` / `RESEND_API_KEY`.
 
 ## Quality Standards
 
-- **Test Coverage**: Aim for 80%+ overall code coverage per CLAUDE.md
+- **Test Coverage**: Aim for 80%+ on `app/` (excluding `app/main.py`
+  glue) per `docs/TECHNICAL-ARCHITECTURE.md`
 - **BDD Clarity**: Every scenario must be understandable by the development team
 - **Reproducibility**: All defects must include exact reproduction steps
 - **Traceability**: Link every test back to a requirement or specification

--- a/.claude/agents/system-architect.md
+++ b/.claude/agents/system-architect.md
@@ -433,28 +433,86 @@ Use the **ATAM (Architecture Tradeoff Analysis Method)**:
 
 ## Project-Specific Domain Analysis
 
-<!--
-TEMPLATE: Fill in project-specific domain analysis here when using this template.
+**Source documents (read these before answering architecture questions):**
+- `docs/PRODUCT-REQUIREMENTS.md`
+- `docs/PRODUCT-ROADMAP.md`
+- `docs/TECHNICAL-ARCHITECTURE.md` (canonical — all ADRs live here)
+- `.claude/PROJECT.md` (platform + key service choices)
 
-Example structure:
-### Bounded Contexts
+### Architecture Style
 
-#### 1. [Context Name]
-**Aggregates:**
-- `Entity` (root) → `ChildEntity1`, `ChildEntity2`
+**Modular monolith** on Google Cloud Run. One FastAPI deployable
+organized by feature module under `app/`. Stateless compute,
+scale-to-zero. Postgres (Neon) is the only system of record.
 
-**Value Objects:**
-- `ValueObject1`, `ValueObject2`
+This style is chosen for budget + solo-team posture. Defend it
+against premature splits into microservices, queues, or caches —
+push back unless a measured constraint demands them.
 
-**Domain Events:**
-- `Event1`, `Event2`
+### Modules (feature-aligned, not layer-aligned)
 
-**Ubiquitous Language:**
-- Term1, Term2, Term3
+| Module | Responsibility |
+|--------|----------------|
+| `app/auth` | Magic-link issuance, verification, sessions |
+| `app/projects` | Per-character workspace CRUD |
+| `app/characters` | Prompt assembly, Anthropic streaming, validator, character schema |
+| `app/api` | Cloud Run health probes |
+| `app/models` | SQLModel entity definitions |
 
-### Context Mapping
-[Diagram showing how contexts relate to each other]
--->
+LLM calls are isolated to `app/characters/generator.py`. Email
+sending is isolated to `app/auth/email.py`. Cross-module imports
+should flow through these seams.
+
+### Domain Entities
+
+| Entity | Purpose | Notes |
+|--------|---------|-------|
+| `User` | Account, owns projects | email + magic-link nonce + last_login_at |
+| `Project` | Workspace for one character | one-to-one with `Character` in v1 |
+| `Character` | Generated sheet (stats + lore + personality) | `data` is JSONB — schema iterates fast |
+| `Generation` | Audit + cost log of an LLM call | prompt, status, model, token counts |
+| `Session` | HTTP-only cookie session | uuid stored as cookie value |
+
+### Ubiquitous Language
+
+| Term | Definition |
+|------|------------|
+| Character | A D&D player-character: stats, class, race, backstory, personality, lore |
+| Project | A workspace for one character — its prompt history and current sheet |
+| Generation | A single LLM call that produces or refines a character |
+| Vibes-first | Generation flow driven by natural-language description, not form fields |
+| Magic link | One-time signed URL emailed to a user; consumes a per-user nonce |
+
+### Architecture Patterns in Use
+
+- **Modular monolith** — one deployable, feature-aligned modules
+- **Server-rendered HTML + HTMX** — no SPA, no JS build step
+- **Streaming over SSE** — token-level streaming from Anthropic to
+  the browser via HTMX `sse-swap`
+- **Dependency injection via FastAPI `Depends`** — `get_session`,
+  `current_user`, and the LLM generator are all swappable in tests
+- **Per-PR ephemeral databases** — Neon branches give each PR an
+  isolated Postgres
+- **JSONB for evolving schema** — `Character.data` stays JSONB until
+  the schema stabilizes
+
+### Key Architectural Decisions (recorded as ADRs)
+
+ADR-001 modular monolith · ADR-002 Anthropic Claude · ADR-003
+magic-link auth · ADR-004 JSONB for character data · ADR-005 Cloud
+Logging (no Sentry) · ADR-006 HTMX SSE for streaming. Full text:
+`docs/TECHNICAL-ARCHITECTURE.md`.
+
+### Architectural Guardrails (push back when violated)
+
+1. Authorization scoping by `current_user.id` is non-negotiable.
+2. The Anthropic SDK is imported only in `app/characters/generator.py`.
+3. Resend SDK is imported only in `app/auth/email.py`.
+4. New persistence belongs in Postgres unless a measured need argues
+   for something else (no Redis, no in-memory caches in v1).
+5. New external services need an ADR.
+6. Cloud Run remains the only compute target; no Kubernetes, no
+   long-running workers in v1.
 
 ## Communication Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,24 +158,25 @@ Every agent output MUST follow these patterns. Full spec: `docs/AGENT-OUTPUT-STA
 
 ## Project-Specific Configuration
 
-<!--
-TEMPLATE: Fill in project-specific details below when using this template.
--->
-
 ### Project Information
 
 - **License**: BSL 1.1 (converts to Apache 2.0 after 3 years per release)
-- **Project Name**: [Your project name]
-- **Repository**: [GitHub repo URL]
-- **Project Board**: [GitHub project board URL]
+- **Project Name**: D&D Character Builder (working name)
+- **Domain**: A D&D character builder — vibes-driven, prompt-based
+- **Repository**: https://github.com/vibeacademy/tck517-app-g
+- **Project Board**: https://github.com/users/tck517/projects/11
 - **Tech Stack**: FastAPI + Jinja2 + HTMX on Python 3.12
 - **Database layer**: SQLModel + Alembic
+- **LLM**: Anthropic Claude (Opus + Haiku) via the Anthropic Python SDK
+- **Email**: Resend (magic-link delivery)
+- **Auth**: Email magic link (no passwords)
+- **Observability**: Google Cloud Logging + Error Reporting
 - **Platform**: Google Cloud Platform (Cloud Run)
 - **Database**: Neon (serverless Postgres with per-PR branching)
 - **Container Registry**: Artifact Registry
 - **Secrets**: Google Secret Manager
 - **Package manager**: uv
-- **Organization**: [GitHub org name]
+- **Organization**: vibeacademy (repo) / tck517 (project board)
 
 ### Build & Test Commands
 

--- a/docs/PRODUCT-REQUIREMENTS.md
+++ b/docs/PRODUCT-REQUIREMENTS.md
@@ -1,112 +1,131 @@
 # Product Requirements Document
 
-<!--
-TEMPLATE: This is a template PRD. Run /bootstrap-product to fill it in
-with your product details through a guided questionnaire.
-
-Replace all [PLACEHOLDER] content with your actual product information.
-Remove the EXAMPLE markers when you replace the content.
--->
-
 ## Product Overview
 
-- **Name**: [Your product name]
-- **Type**: [Web app | Mobile app | API service | CLI tool | Library | Other]
-- **Category**: [B2B SaaS | B2C Consumer | Developer tools | E-commerce | Other]
+- **Name**: D&D Character Builder (working name)
+- **Domain**: A D&D character builder
+- **Type**: Web application
+- **Category**: Content / Media platform
 
 ## Vision and Problem Statement
 
 ### Problem
 
-[Describe the problem your product solves in 1-3 sentences.]
-
-<!-- EXAMPLE -- replace with your content:
-Development teams waste 40% of their time on repetitive coordination tasks
-that could be automated with AI agents, but lack safe guardrails for
-integrating AI into their workflows.
--->
+Building a balanced, playable D&D character with a real personality, traits,
+and consistent lore is slow and tedious. Rolling for every attribute often
+yields a flat mishmash — no clear strengths, no notable weaknesses, no
+character to play.
 
 ### Vision
 
-[One sentence describing the ideal future state your product creates.]
+Make it easy to create compelling D&D characters with natural-language
+prompts — based on **vibes**, not checkboxes on a form.
 
 ### How People Solve This Today
 
-[What alternatives or workarounds exist? Why are they inadequate?]
+Players today use D&D Beyond and similar online character builders. These
+tools are exhaustive but feel like work: form-driven, WYSIWYG, optimized
+for stat correctness rather than character voice. Personality, backstory,
+and lore are left to the user to bolt on after the mechanical sheet is
+done — and rarely end up consistent with the rolled stats.
 
 ## Target Audience
 
 ### Primary Users
 
-- **Who**: [Role, context, and goal in one sentence]
-- **Pain Point**: [The #1 problem they face]
-- **Current Solution**: [How they solve it today]
+- **Who**: A tabletop games hobbyist who wants imaginative, lore-consistent
+  characters built from prompts, not WYSIWYG outfit-pickers.
+- **Pain Point**: Random rolls produce flat, unplayable characters with no
+  meaningful strengths or weaknesses — and no internal consistency between
+  stats, backstory, and personality.
+- **Current Solution**: D&D Beyond and other form-based character builders.
 
 ### Secondary Users
 
-[Other user types, or "None -- single user type"]
+None — single user type for v1.
 
 ## Features
 
 ### MVP (Must Have)
 
-<!-- List 3-5 features that MUST be in v1. Be specific and testable. -->
-
-- [ ] [Feature 1 -- specific and measurable]
-- [ ] [Feature 2]
-- [ ] [Feature 3]
+- [ ] Email-based user authentication (sign up, sign in, password reset)
+- [ ] Projects: each project is a workspace for a single character
+  (create, list, open, rename, delete)
+- [ ] Character builder UI driven by a natural-language text prompt that
+  generates a believable, playable character (stats + personality +
+  lore, internally consistent)
 
 ### Out of Scope (v1)
 
-<!-- Equally important: what are you NOT building? -->
-
-- [Feature explicitly excluded from v1]
+- Visual / WYSIWYG controls (sliders, dropdowns, outfit pickers, portraits)
+- Mobile-native apps (web only)
+- Multi-user collaboration on a character
+- Campaign / party management
+- Marketplace, sharing, or social feed
+- Payments / subscriptions
+- Export to D&D Beyond or VTT integrations
 
 ### Core Value Proposition
 
-[The ONE thing your product must do exceptionally well.]
+Generate believable, engaging, relatable D&D characters from a few
+sentences of prompt — fast enough that creating a character feels like
+play, not paperwork.
 
 ## Success Metrics
 
-| Metric | Target (3 months) |
-|--------|-------------------|
-| Primary: [e.g., Monthly active users] | [e.g., 500] |
-| Secondary: [e.g., Retention rate] | [e.g., 60%] |
+| Metric | Target (3 months post-launch) |
+|--------|-------------------------------|
+| Primary: Registered users | 100 |
 
 ## Competitive Analysis
 
-| Competitor | Strength | Weakness | Your Differentiator |
-|-----------|----------|----------|---------------------|
-| [Name] | [What they do well] | [Where they fall short] | [Why you win] |
+| Competitor | Strength | Weakness | Our Differentiator |
+|------------|----------|----------|--------------------|
+| D&D Beyond | Comprehensive rules coverage, official content licensing, large user base | Form-driven and exhaustive; feels like work; weak on personality and lore | Prompt-first, vibes-driven flow that produces a coherent character (stats + lore + personality) in one pass — feels like fun |
+
+**Key differentiator**: It feels like fun. Other builders feel like work.
 
 ## Constraints and Requirements
 
-- **Timeline**: [When do you need to launch?]
-- **Budget**: [Resource constraints]
-- **Technical**: [Must-use technologies, compliance requirements]
-- **Team**: [Available expertise]
+- **Timeline**: 2–3 months to launch (target: 2026-07-01 to 2026-08-01)
+- **Budget**: Limited resources — pick managed services with generous free
+  tiers; avoid infra that needs ops attention
+- **Technical**: FastAPI + Jinja2 + HTMX on Python 3.12, SQLModel + Alembic,
+  deployed to Google Cloud Run with Neon Postgres (per-PR branching),
+  Artifact Registry for images, Secret Manager for credentials, `uv`
+  as the package manager
+- **Team**: Solo / small (per the budget constraint)
 
 ## Non-Functional Requirements
 
 | Category | Requirement |
 |----------|-------------|
-| Security | [Auth approach, data protection] |
-| Performance | [Latency, throughput targets] |
-| Scalability | [Expected load, growth] |
-| Accessibility | [WCAG level, requirements] |
+| Security | Email + password auth with hashed passwords; session-based auth; HTTPS only; secrets in Google Secret Manager (never in repo) |
+| Performance | Character generation must feel interactive — surface streaming or progress within 2s, full result within 30s |
+| Scalability | Cloud Run autoscale to zero acceptable for v1; sized for ~100 users in first 3 months |
+| Accessibility | Keyboard navigable; readable contrast; screen-reader friendly text-first UI (text-only scope helps) |
 
 ## Dependencies
 
-- [External service or tool this product depends on]
+- LLM provider for character generation (cost is the dominant variable;
+  selection deferred to architecture phase)
+- Neon (Postgres + per-PR branching)
+- Google Cloud Run, Artifact Registry, Secret Manager
+- GitHub (source, CI/CD, project board)
 
 ## Risks and Mitigations
 
 | Risk | Impact | Mitigation |
 |------|--------|------------|
-| [Risk description] | High/Medium/Low | [How to prevent or handle] |
+| LLM cost per character exceeds free-tier budget at 100 users | High | Pick a cost-aware default model; cap tokens per generation; cache common prompt structures |
+| Generated characters feel generic ("sounds like ChatGPT") and don't deliver on the "fun" differentiator | High | Invest prompt-engineering time in MVP; dogfood with target users early; measure qualitative feedback alongside signup count |
+| D&D rules accuracy errors in generated stats erode trust | Medium | Validate stat blocks against rule constraints in code; flag generated content as "draft — verify before play" until validation matures |
+| Scope creep into visual controls undermines the "vibes" thesis | Medium | Out-of-scope list above is binding for v1; revisit only after MVP signups target hit |
 
 ## Glossary
 
 | Term | Definition |
 |------|------------|
-| [Domain term] | [What it means in this product] |
+| Character | A single D&D player-character: stats, class, race, backstory, personality, and lore |
+| Project | A workspace for one character — its prompt history, generated drafts, and current sheet |
+| Vibes-first | Generation flow driven by natural-language description rather than form fields |

--- a/docs/PRODUCT-ROADMAP.md
+++ b/docs/PRODUCT-ROADMAP.md
@@ -1,74 +1,90 @@
 # Product Roadmap
 
-<!--
-TEMPLATE: This is a template roadmap. Run /bootstrap-product to generate
-a roadmap based on your PRD.
-
-Replace all [PLACEHOLDER] content with your actual product plans.
-Remove the EXAMPLE markers when you replace the content.
--->
-
 ## Overview
 
-[One paragraph describing the product direction and timeline.]
+A 2–3 month build aimed at launching a vibes-first D&D character builder
+by July–August 2026. Phase 1 delivers a usable prompt-to-character flow
+behind email auth with per-character workspaces. Phase 2 iterates on the
+generation quality and lightweight sharing once we have real user
+feedback. Phase 3 expands surface area only if we hit the 100-user
+3-month signup target.
 
 ## Phase 1: MVP
 
-- **Target**: [Date or timeframe]
-- **Goal**: Deliver core value proposition to first users
+- **Target**: 2026-07-01 to 2026-08-01 (2–3 months from 2026-05-01)
+- **Goal**: Deliver a working prompt-to-character experience that feels
+  like fun, not paperwork
 
 ### Features
 
 | Feature | Priority | Status |
 |---------|----------|--------|
-| [Feature from PRD] | P0 | Backlog |
-| [Feature from PRD] | P0 | Backlog |
-| [Feature from PRD] | P1 | Backlog |
+| Email auth (sign up, sign in, password reset) | P0 | Backlog |
+| Projects: per-character workspaces (CRUD) | P0 | Backlog |
+| Prompt-driven character builder (stats + personality + lore in one pass) | P0 | Backlog |
+| Character sheet view (read-only render of generated character) | P0 | Backlog |
+| Regenerate / refine character from updated prompt | P1 | Backlog |
+| Basic D&D rules validation on generated stat blocks | P1 | Backlog |
 
 ### Success Criteria
 
-- [ ] [Primary metric from PRD] reaches [target]
-- [ ] [Acceptance criterion]
+- [ ] 100 registered users within 3 months of launch
+- [ ] A new user can go from sign-up to a generated character in under
+      5 minutes
+- [ ] Generated characters consistently include stats, personality,
+      and lore that reference each other (qualitative dogfood review)
 
 ## Phase 2: Iteration
 
-- **Target**: Post-MVP (1-2 months after launch)
-- **Goal**: Expand based on user feedback
+- **Target**: 1–2 months post-launch (2026-09 to 2026-10)
+- **Goal**: Sharpen generation quality and reduce regen friction based
+  on real user feedback
 
-### Features
+### Candidate Features (re-prioritize from feedback)
 
 | Feature | Priority | Status |
 |---------|----------|--------|
-| [Based on user feedback] | TBD | Backlog |
+| Prompt templates / starter vibes (e.g. "grizzled veteran", "naive prodigy") | TBD | Backlog |
+| Inline edit of generated text fields (without losing other consistency) | TBD | Backlog |
+| Shareable read-only character link | TBD | Backlog |
+| Cost / token usage surfacing per project | TBD | Backlog |
 
 ### Success Criteria
 
-- [ ] [Retention or engagement metric]
+- [ ] Returning-user rate (signup → second session) measurable and
+      improving week-over-week
+- [ ] Generation cost per character within budget at 2x current user count
 
 ## Phase 3: Growth
 
-- **Target**: [3-6 months post-launch]
-- **Goal**: Scale and expand capabilities
+- **Target**: 3–6 months post-launch
+- **Goal**: Expand only if MVP signups target was hit; otherwise stay
+  in Phase 2 and keep iterating
 
-### Features
+### Candidate Features
 
 | Feature | Priority | Status |
 |---------|----------|--------|
-| [Growth feature] | TBD | Backlog |
+| Light visual controls (opt-in, layered on top of the prompt flow) | TBD | Backlog |
+| Export to common VTT / character-sheet formats | TBD | Backlog |
+| Party / campaign workspace (multiple characters together) | TBD | Backlog |
 
 ## Milestone Definitions
 
 | Milestone | Criteria | Target Date |
 |-----------|----------|-------------|
-| M1: MVP Launch | Core features live, first users onboarded | [Date] |
-| M2: Product-Market Fit | [Retention/engagement threshold] | [Date] |
-| M3: Growth | [Scale/revenue threshold] | [Date] |
+| M1: MVP Launch | Auth + projects + prompt-driven character generation live in production | 2026-08-01 |
+| M2: First 100 Users | 100 registered users | 2026-11-01 |
+| M3: Product-Market Fit Signal | Returning-user rate trending up; qualitative "feels like fun" feedback dominates | 2027-Q1 |
 
 ## Constraints and Risks
 
 | Risk | Phase | Mitigation |
 |------|-------|------------|
-| [Risk from PRD] | 1 | [Mitigation strategy] |
+| LLM cost overruns the limited budget | 1, 2 | Cap tokens per generation; pick cost-aware default model; monitor cost per character |
+| Generated characters feel generic | 1 | Heavy prompt-engineering investment in MVP; dogfood with target users before launch |
+| Scope creep into visual controls dilutes the "vibes" differentiator | 1, 2 | PRD out-of-scope list is binding for v1; revisit only after M2 |
+| Solo / small team capacity | All | Use managed services (Cloud Run, Neon, Secret Manager); skip undifferentiated infra work |
 
 ## Dependencies
 
@@ -79,11 +95,11 @@ Phase 1: MVP
 Phase 2: Iteration (requires user feedback from Phase 1)
     |
     v
-Phase 3: Growth (requires product-market fit from Phase 2)
+Phase 3: Growth (requires hitting M2 signup target)
 ```
 
 ## Revision History
 
 | Date | Change | Author |
 |------|--------|--------|
-| [Date] | Initial roadmap creation | [Name] |
+| 2026-05-01 | Initial roadmap from /bootstrap-product | Teddy Kim |

--- a/docs/TECHNICAL-ARCHITECTURE.md
+++ b/docs/TECHNICAL-ARCHITECTURE.md
@@ -1,0 +1,382 @@
+# Technical Architecture
+
+## Overview
+
+A single-process FastAPI web app, server-rendered with Jinja2 + HTMX,
+running on Google Cloud Run with a Neon Postgres backend. Character
+generation is delegated to the Anthropic API. Authentication is
+passwordless (magic link via Resend). All state of record lives in
+Postgres; Cloud Run is stateless and scales to zero.
+
+This is a **modular monolith** — one deployable, organized into
+feature-aligned modules under `app/`. Per the budget constraint and
+solo-team posture, we explicitly defer microservices, queues,
+caches, and any infra that needs ops attention until product-market
+fit is proven.
+
+## Technology Stack
+
+### Frontend
+
+- **Framework**: Server-rendered Jinja2 templates + HTMX 2.x — no build
+  step, no SPA, no client framework.
+- **Styling**: Pico.css via CDN (class-less; replace if we outgrow it).
+- **Interactivity**: HTMX for AJAX, form posts, and fragment swaps.
+  Streaming character generation uses HTMX SSE (`hx-ext="sse"`) so the
+  generated character text appears progressively.
+- **No JS bundler / no Node toolchain.** The CI `node` job auto-skips.
+
+### Backend
+
+- **Runtime**: Python 3.12
+- **Framework**: FastAPI + Uvicorn
+- **Templates**: Jinja2 (rendered server-side; partials returned for
+  HTMX swaps)
+- **DB layer**: SQLModel + Alembic
+- **LLM client**: `anthropic` Python SDK (streaming Messages API)
+- **Email**: `resend` Python SDK (magic-link delivery)
+- **Auth**: Custom magic-link implementation — short-lived signed tokens
+  (itsdangerous `URLSafeTimedSerializer`), session cookie on success.
+  No third-party auth provider for v1.
+- **Testing**: pytest + httpx (`fastapi.testclient.TestClient`) with an
+  in-memory SQLite fixture and `app.dependency_overrides[get_session]`.
+- **Package manager**: uv
+- **Lint / format / types**: ruff + mypy (config in `pyproject.toml`)
+
+### Database
+
+- **Primary**: Neon Postgres
+  - One project per environment (dev / staging / prod)
+  - **Per-PR branching** for ephemeral preview environments — every PR
+    gets its own isolated DB branch
+- **Cache**: None for v1. Postgres + Cloud Run revision-level memory is
+  enough at 100-user scale.
+- **Search**: None for v1.
+
+### Infrastructure
+
+- **Compute**: Google Cloud Run (one service, scale-to-zero, min
+  instances = 0 in dev / staging, = 1 in prod once we have paying users
+  to keep cold-start out of the magic-link redemption path)
+- **Container Registry**: Google Artifact Registry
+- **Secrets**: Google Secret Manager (`ANTHROPIC_API_KEY`,
+  `RESEND_API_KEY`, `DATABASE_URL`, `SESSION_SECRET`,
+  `MAGIC_LINK_SECRET`)
+- **CI/CD**: GitHub Actions → Cloud Run (auth via Workload Identity
+  Federation)
+- **Logging / Errors**: Google Cloud Logging + Error Reporting (auto-
+  groups unhandled FastAPI exceptions). View at
+  `https://console.cloud.google.com/errors`.
+
+## System Design
+
+### Component Diagram
+
+```text
+        ┌────────────────────┐
+        │      Browser       │
+        │  (HTMX + Pico.css) │
+        └─────────┬──────────┘
+                  │ HTTPS
+                  v
+        ┌────────────────────┐                 ┌──────────────────────┐
+        │  FastAPI on        │── messages.api ─▶ Anthropic API        │
+        │  Cloud Run         │  (streaming)    │ (Claude Opus / Haiku) │
+        │                    │                 └──────────────────────┘
+        │  ┌──────────────┐  │                 ┌──────────────────────┐
+        │  │ auth         │  │── send.email ──▶ Resend API           │
+        │  │ projects     │  │                 └──────────────────────┘
+        │  │ characters   │  │                 ┌──────────────────────┐
+        │  │ generations  │  │── psycopg ─────▶ Neon Postgres        │
+        │  └──────────────┘  │                 │  (per-PR branches)   │
+        └─────────┬──────────┘                 └──────────────────────┘
+                  │ stdout / unhandled exc
+                  v
+        ┌────────────────────┐
+        │ Cloud Logging /    │
+        │ Error Reporting    │
+        └────────────────────┘
+```
+
+### Module Layout
+
+```text
+app/
+  main.py              # FastAPI app, middleware, route registration
+  config.py            # Pydantic Settings (env-driven)
+  db.py                # engine + get_session dependency
+  templates.py         # Jinja2 template loader
+  auth/
+    routes.py          # /auth/login, /auth/verify, /auth/logout
+    tokens.py          # magic-link sign / verify
+    email.py           # Resend integration
+    deps.py            # current_user dependency
+  projects/
+    routes.py          # /projects, /projects/{id}
+    service.py         # CRUD logic
+  characters/
+    routes.py          # /projects/{id}/character (HTMX endpoints)
+    generator.py       # Anthropic prompt assembly + streaming
+    schema.py          # Pydantic shape of a generated character
+    validator.py       # D&D rules sanity checks on stat blocks
+  api/
+    health.py          # /healthz for Cloud Run probes
+  models/
+    user.py
+    project.py
+    character.py
+    generation.py
+templates/
+  base.html
+  home.html
+  auth/
+  projects/
+  characters/
+  _fragments/          # HTMX fragment templates
+```
+
+### Data Flow — Character Generation
+
+1. User opens a project, types a prompt, submits the HTMX form.
+2. The `characters` route persists a `Generation` row (status =
+   `pending`, prompt stored), then opens an SSE stream.
+3. `generator.py` calls Anthropic's streaming Messages API. Tokens are
+   forwarded to the browser as SSE events that HTMX swaps into the page
+   in real time.
+4. On stream completion, the generator parses the model's structured
+   output (JSON mode) into the `Character` schema, runs `validator.py`
+   for rules sanity checks, and persists the `Character` row linked to
+   the project.
+5. The `Generation` row is updated with status (`succeeded` / `failed`)
+   plus token counts for cost tracking.
+
+### Data Flow — Magic-Link Auth
+
+1. User submits email at `/auth/login`.
+2. Server creates / fetches a `User` row, mints a signed token
+   (`URLSafeTimedSerializer`, TTL 15 min, single-use nonce stored on the
+   user row), and emails a link to `/auth/verify?token=…` via Resend.
+3. On click, server verifies signature + TTL + nonce, rotates the
+   nonce (invalidating the link), sets a session cookie
+   (HTTP-only, Secure, SameSite=Lax), and redirects to `/projects`.
+
+### API Design
+
+- **REST + HTML fragments.** Most endpoints return HTML (full page or
+  HTMX fragment). No public JSON API in v1.
+- **Streaming**: SSE for character generation only (`text/event-stream`).
+- **CSRF**: HTMX requests carry a per-session token in a custom header,
+  validated by middleware.
+- **Health**: `GET /healthz` (200 = liveness; used by Cloud Run probes).
+
+## Data Models
+
+### Core Entities
+
+```text
+User
+  id (uuid, pk)
+  email (citext, unique)
+  magic_link_nonce (text, nullable)   -- rotated on every successful login
+  magic_link_sent_at (timestamptz, nullable)
+  created_at (timestamptz)
+  last_login_at (timestamptz, nullable)
+
+Project
+  id (uuid, pk)
+  user_id (fk → User)                 -- one workspace per character
+  name (text)
+  created_at, updated_at (timestamptz)
+
+Character
+  id (uuid, pk)
+  project_id (fk → Project, unique)   -- exactly one character per project in v1
+  data (jsonb)                        -- the generated sheet (stats, lore, personality)
+  created_at, updated_at (timestamptz)
+
+Generation
+  id (uuid, pk)
+  project_id (fk → Project)
+  prompt (text)
+  status (enum: pending | succeeded | failed)
+  model (text)                        -- e.g. "claude-opus-4-7"
+  input_tokens (int, nullable)
+  output_tokens (int, nullable)
+  error (text, nullable)
+  created_at, completed_at (timestamptz, nullable)
+
+Session
+  id (uuid, pk)                       -- value stored in HTTP-only cookie
+  user_id (fk → User)
+  created_at (timestamptz)
+  expires_at (timestamptz)
+```
+
+### Why JSONB for `Character.data`?
+
+The character schema will evolve quickly during MVP iteration as we
+tune the prompt and the validator. A JSONB column with a Pydantic
+schema in code lets us reshape without migrations on every prompt
+tweak. Migrations come later if we need to query into specific fields.
+
+### Migrations
+
+- Alembic, autogenerate from SQLModel metadata.
+- Per-PR Neon branches mean every PR runs its own `alembic upgrade head`
+  on a fresh database — schema changes are caught before merge.
+
+## Development Standards
+
+### Code Style
+
+- **Linting**: `ruff check .` (rules `E,F,I,W,B,UP`)
+- **Formatting**: `ruff format .`
+- **Types**: `mypy app/` — `check_untyped_defs = true`
+- **Naming**: `snake_case` for functions/modules; `PascalCase` for
+  SQLModel / Pydantic classes; route paths kebab-case (`/auth/verify`,
+  `/projects/{id}`).
+
+### Testing Requirements
+
+- **Unit tests**: pytest, in-memory SQLite via `StaticPool` fixture.
+- **HTTP tests**: `TestClient` with `app.dependency_overrides[get_session]`
+  pointing at the test session.
+- **HTMX fragment tests**: assert HTML substrings AND assert
+  `"<html" not in response.text` to catch full-page leaks from fragment
+  endpoints.
+- **LLM tests**: do **not** call the real Anthropic API in tests. Inject
+  a fake generator via `app.dependency_overrides` that returns canned
+  output. Real-API smoke tests live in a separate, opt-in
+  `tests/smoke/` suite gated on `RUN_SMOKE_TESTS=1`.
+- **Coverage**: aim for 80% on `app/` excluding `app/main.py` glue.
+
+### Documentation
+
+- One ADR per significant architectural decision (see ADRs below).
+- Module-level docstring on each new feature module explaining its
+  responsibility.
+- Per-route handler: a one-line docstring describing what it returns
+  (full page vs. HTMX fragment).
+
+### Code Review
+
+- All CI checks green (lint, types, tests, build).
+- Per-PR Neon branch present and `alembic upgrade head` succeeded
+  (caught by CI).
+- New env vars added to `.env.example` AND to Secret Manager for
+  staging/prod.
+- For LLM-touching changes: include before/after sample generations in
+  the PR description.
+
+## Security
+
+### Authentication
+
+Email magic link only. Tokens are signed with `itsdangerous`
+(`URLSafeTimedSerializer`) using `MAGIC_LINK_SECRET`, expire in 15
+minutes, and are single-use (per-user nonce rotated on consumption).
+Session cookies are HTTP-only, Secure, SameSite=Lax.
+
+### Authorization
+
+Single-tenant model: a user can only access their own `Project`s and
+their nested `Character` / `Generation` rows. Enforced via a
+`current_user` FastAPI dependency that filters every query by
+`user_id`. No row-level security (RLS) in Postgres for v1.
+
+### Data Protection
+
+- All traffic HTTPS (Cloud Run terminates TLS).
+- Secrets only in Google Secret Manager — never in repo, never in env
+  files committed to git. `.env.example` lists names, not values.
+- No PII beyond email addresses; no payment data; no health data.
+- Anthropic and Resend API keys scoped to the project; rotated via
+  Secret Manager versions (no code changes needed for rotation).
+- Cloud Logging redacts request bodies on auth routes (avoid logging
+  email addresses in clear).
+
+## Scalability
+
+### Current Targets
+
+- 100 registered users in 3 months.
+- Peak concurrent generations: low single digits.
+- Cloud Run: max instances 5, concurrency 80 — well within budget.
+
+### Scaling Strategy
+
+The honest answer: we do not need to scale for v1. The architecture
+naturally scales horizontally (stateless Cloud Run + managed Postgres),
+so when scaling becomes a real concern we will:
+
+1. Raise Cloud Run max instances and add `min_instances >= 1` in prod.
+2. Move character generation onto a background worker
+   (Cloud Tasks → Cloud Run job) so the request thread is freed.
+3. Add a Postgres read replica or pgBouncer if Neon connections become
+   the bottleneck.
+4. Add caching only when a measured query proves it necessary.
+
+## Architecture Decision Records
+
+### ADR-001: Modular monolith on Cloud Run
+
+- **Status**: Accepted
+- **Context**: Solo-team, limited budget, 100-user 3-month target.
+- **Decision**: Single FastAPI deployable, scale-to-zero on Cloud Run.
+- **Consequences**: Lowest infra surface area; one CI pipeline; easy
+  local dev. We accept that splitting later requires real refactor work.
+
+### ADR-002: Anthropic Claude as the LLM provider
+
+- **Status**: Accepted
+- **Context**: Need strong long-form, voicey character / lore generation
+  with structured output. Cost matters.
+- **Decision**: Anthropic Claude — Opus for first-pass generations
+  (quality matters most for the "feels like fun" differentiator); Haiku
+  for cheaper regenerations and prompt iteration in dev.
+- **Consequences**: Vendor lock-in to Anthropic. We mitigate by keeping
+  the LLM call isolated in `characters/generator.py` so swapping later
+  is a one-file change.
+
+### ADR-003: Magic-link auth, no passwords
+
+- **Status**: Accepted
+- **Context**: PRD calls for "email-based authentication." Passwords
+  add an attack surface (storage, reset flow, hashing) that buys little
+  for a hobbyist tool.
+- **Decision**: Magic-link only via Resend. Sessions via signed
+  HTTP-only cookies.
+- **Consequences**: Email deliverability becomes a critical dependency
+  (mitigated by Resend's reputation). User cannot log in if their inbox
+  is unavailable — acceptable for the target user.
+
+### ADR-004: JSONB for character data
+
+- **Status**: Accepted
+- **Context**: Character schema will iterate fast during MVP. We don't
+  yet need to query into character fields.
+- **Decision**: Store the generated character as a JSONB blob with a
+  Pydantic schema enforced in application code.
+- **Consequences**: No migrations needed for prompt-shape changes.
+  Trade-off: queries that filter by character traits are deferred until
+  schema stabilizes.
+
+### ADR-005: Cloud Logging + Error Reporting (no Sentry)
+
+- **Status**: Accepted
+- **Context**: Need observability; budget is tight; everything else is
+  on GCP.
+- **Decision**: Use Cloud Logging + Error Reporting. Initialize
+  structured logging in `main.py`; let Cloud Run capture stdout.
+- **Consequences**: Less polished error UX than Sentry. Reconsider
+  after MVP if triage time becomes a pain point.
+
+### ADR-006: HTMX SSE for streaming generation
+
+- **Status**: Accepted
+- **Context**: Character generation can take 5–30s; users need feedback.
+- **Decision**: Stream the Anthropic response over SSE; HTMX `sse-swap`
+  paints tokens as they arrive.
+- **Consequences**: Cloud Run supports SSE up to its 60-minute request
+  timeout — well within our 30-second target. Long-lived connections
+  count against per-instance concurrency; acceptable at our scale.


### PR DESCRIPTION
## Summary

Output of the three bootstrap commands run in sequence:

- `/bootstrap-product` → `docs/PRODUCT-REQUIREMENTS.md`, `docs/PRODUCT-ROADMAP.md`
- `/bootstrap-architecture` → `docs/TECHNICAL-ARCHITECTURE.md`, `.claude/PROJECT.md`
- `/bootstrap-agents` → updated `.claude/agents/{quality-engineer,github-ticket-worker,pr-reviewer,system-architect}.md` and `CLAUDE.md` Project Information

This is **Quick Fix Protocol** (no linked ticket) — documentation and agent configuration only, no code changes.

## What's defined

- **Product**: D&D character builder; vibes-driven, prompt-based; 100 registered users in 3 months
- **Architecture**: modular monolith on GCP Cloud Run + Neon Postgres; FastAPI + Jinja2 + HTMX; Anthropic Claude (Opus + Haiku) for generation; Resend for magic-link email; Google Cloud Logging + Error Reporting for observability
- **6 ADRs**: monolith, Anthropic, magic-link auth, JSONB for character data, Cloud Logging (no Sentry), HTMX SSE for streaming

## Test plan

- [x] `ruff check` — passed via pre-push hook
- [x] `pytest` — 22/22 passing via pre-push hook
- [x] Verified no `TEMPLATE:` placeholders remain in `.claude/agents/` or `CLAUDE.md`
- [ ] Reviewer skim of `docs/PRODUCT-REQUIREMENTS.md` and `docs/TECHNICAL-ARCHITECTURE.md` for direction agreement before ticket #3 builds on this foundation

🤖 Generated with [Claude Code](https://claude.com/claude-code)