### PR TITLE
feat(auth): magic-link token sign + verify with TTL and single-use nonce

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Local development environment.
+#
+# Copy this file to .env and fill in the values. Never commit .env —
+# it's gitignored. In production, these values come from Google Secret
+# Manager, mounted onto the Cloud Run revision via --set-secrets.
+
+# Database connection. Default is local SQLite for fast iteration; set
+# this to your Neon branch URL when working against Postgres.
+DATABASE_URL=sqlite:///./dev.db
+
+# Self-referential URL for redirects and email links. Cloud Run reads
+# this from the X-Forwarded-Host header at runtime; the value here is
+# only used as a fallback for local dev.
+APP_URL=http://localhost:8080
+
+# One of: development | test | preview | staging | production.
+# Non-dev environments enforce stricter validation (no SQLite, etc).
+ENVIRONMENT=development
+
+# 32-byte hex secret used to sign magic-link tokens. Generate with:
+#   python -c "import secrets; print(secrets.token_hex(32))"
+# In production this comes from Secret Manager and rotates on a schedule.
+MAGIC_LINK_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,10 @@ logs/
 
 # Project-specific ignores (add below this line)
 
+# Whitelist .env.example — the framework section's `.env.*` rule excludes
+# it, but we need it tracked as the documented env-var contract.
+!.env.example
+
 # Workshop roster — input + generated output. Contains participant emails;
 # never commit. Use scripts/roster.example.csv as the format reference.
 roster.csv

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,0 +1,5 @@
+"""Authentication module — magic-link tokens, sessions, login routes.
+
+This ticket lands the token sign / verify functions only. Routes,
+session middleware, and `current_user` arrive in #5 and #6.
+"""

--- a/app/auth/tokens.py
+++ b/app/auth/tokens.py
@@ -1,0 +1,67 @@
+"""Magic-link token sign + verify.
+
+Pure functions. No DB, no HTTP, no logging of token contents.
+
+The token encodes `(email, nonce)` and is signed with
+`itsdangerous.URLSafeTimedSerializer` against `Settings.magic_link_secret`.
+TTL is hard-coded at 15 minutes; `nonce` is the row-level single-use
+guarantee, rotated by the auth route on consumption (a later ticket).
+"""
+
+from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
+
+from app.config import get_settings
+
+_TTL_SECONDS = 60 * 15  # 15 minutes
+_SALT = "magic-link"
+
+
+class MagicLinkInvalid(Exception):
+    """Token signature does not match — tampered, wrong secret, or garbage."""
+
+
+class MagicLinkExpired(Exception):
+    """Token is correctly signed but older than the 15-minute TTL."""
+
+
+class MagicLinkConfigError(Exception):
+    """`MAGIC_LINK_SECRET` env var is unset or empty."""
+
+
+def _serializer() -> URLSafeTimedSerializer:
+    secret = get_settings().magic_link_secret.get_secret_value()
+    if not secret:
+        raise MagicLinkConfigError(
+            "MAGIC_LINK_SECRET env var is not set. Magic-link auth cannot "
+            "function. In production, this comes from Google Secret Manager; "
+            "for local dev set it in .env (any random hex string is fine)."
+        )
+    return URLSafeTimedSerializer(secret, salt=_SALT)
+
+
+def sign_magic_link(email: str, nonce: str) -> str:
+    """Return a URL-safe signed token encoding `(email, nonce)`.
+
+    The token is opaque to callers — no parsing or guessing.
+    """
+    return _serializer().dumps({"email": email, "nonce": nonce})
+
+
+def verify_magic_link(token: str) -> tuple[str, str]:
+    """Verify a token and return `(email, nonce)`.
+
+    Raises `MagicLinkExpired` if the token is correctly signed but older
+    than the 15-minute TTL. Raises `MagicLinkInvalid` for any other
+    failure mode (tampered, signed with a different secret, wrong salt,
+    malformed payload).
+    """
+    try:
+        payload = _serializer().loads(token, max_age=_TTL_SECONDS)
+    except SignatureExpired as exc:
+        raise MagicLinkExpired() from exc
+    except BadSignature as exc:
+        raise MagicLinkInvalid() from exc
+
+    if not isinstance(payload, dict) or "email" not in payload or "nonce" not in payload:
+        raise MagicLinkInvalid()
+    return payload["email"], payload["nonce"]

--- a/app/config.py
+++ b/app/config.py
@@ -8,7 +8,7 @@ or Cloud Run Secret Manager mounts.
 from functools import lru_cache
 from typing import Self
 
-from pydantic import field_validator, model_validator
+from pydantic import SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,6 +18,11 @@ class Settings(BaseSettings):
     database_url: str = "sqlite:///./dev.db"
     app_url: str = "http://localhost:8080"
     environment: str = "development"
+    # Secret used to sign magic-link tokens (HMAC via itsdangerous). Has an
+    # empty default so Settings() construction stays cheap in dev/test;
+    # the auth code raises explicitly if it's empty at call time. See
+    # app/auth/tokens.py.
+    magic_link_secret: SecretStr = SecretStr("")
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "alembic>=1.13",
     "psycopg[binary,pool]>=3.2",
     "pydantic-settings>=2.6",
+    "itsdangerous>=2.2",
 ]
 
 [project.optional-dependencies]

--- a/tests/auth/test_tokens.py
+++ b/tests/auth/test_tokens.py
@@ -1,0 +1,142 @@
+"""Magic-link token tests.
+
+The five DoD assertions from issue #4:
+
+  1. Round-trip: verify(sign(...)) returns the original (email, nonce)
+  2. A token mutated by one byte raises MagicLinkInvalid
+  3. A token signed with a different secret raises MagicLinkInvalid
+  4. A token older than the 15-minute TTL raises MagicLinkExpired
+  5. With no MAGIC_LINK_SECRET set, sign_magic_link raises a config error
+
+Plus a few small belt-and-suspenders cases (different salt, malformed
+payload) that fall out of the same machinery.
+"""
+
+import time
+
+import pytest
+from itsdangerous import URLSafeTimedSerializer
+
+from app.auth.tokens import (
+    MagicLinkConfigError,
+    MagicLinkExpired,
+    MagicLinkInvalid,
+    sign_magic_link,
+    verify_magic_link,
+)
+from app.config import get_settings
+
+# 32-byte hex used by every test that needs a non-empty secret.
+_TEST_SECRET = "0" * 64
+
+
+@pytest.fixture(autouse=True)
+def _set_test_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default to a non-empty secret. Tests that need it empty override."""
+    monkeypatch.setenv("MAGIC_LINK_SECRET", _TEST_SECRET)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def test_sign_then_verify_round_trips_email_and_nonce() -> None:
+    token = sign_magic_link("alice@example.com", "n-abc123")
+    email, nonce = verify_magic_link(token)
+    assert email == "alice@example.com"
+    assert nonce == "n-abc123"
+
+
+def test_token_mutated_by_one_byte_raises_invalid() -> None:
+    token = sign_magic_link("a@b.com", "n1")
+    # Flip a single character somewhere in the middle of the payload.
+    mutated = token[:-3] + ("A" if token[-3] != "A" else "B") + token[-2:]
+    with pytest.raises(MagicLinkInvalid):
+        verify_magic_link(mutated)
+
+
+def test_token_signed_with_different_secret_raises_invalid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Sign under a different secret using itsdangerous directly. Then
+    # verify under the test secret — signature must not match.
+    foreign_serializer = URLSafeTimedSerializer("a-different-secret", salt="magic-link")
+    foreign_token = foreign_serializer.dumps({"email": "a@b.com", "nonce": "n1"})
+
+    with pytest.raises(MagicLinkInvalid):
+        verify_magic_link(foreign_token)
+
+
+def test_token_older_than_ttl_raises_expired(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Jump time forward past the 15-minute TTL between sign and verify.
+    real_time = time.time
+    fake_now = real_time()
+
+    def fake_time() -> float:
+        return fake_now
+
+    # Sign at "now"
+    monkeypatch.setattr(time, "time", fake_time)
+    token = sign_magic_link("a@b.com", "n1")
+
+    # Verify "16 minutes later" — past the 900s TTL
+    later = fake_now + (60 * 16)
+    monkeypatch.setattr(time, "time", lambda: later)
+    with pytest.raises(MagicLinkExpired):
+        verify_magic_link(token)
+
+
+def test_sign_with_unset_secret_raises_config_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MAGIC_LINK_SECRET", "")
+    get_settings.cache_clear()
+    with pytest.raises(MagicLinkConfigError):
+        sign_magic_link("a@b.com", "n1")
+
+
+def test_verify_with_unset_secret_also_raises_config_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # First sign a valid token with a real secret
+    token = sign_magic_link("a@b.com", "n1")
+    # Then unset the secret and try to verify — should fail loud, not
+    # silently succeed or return None.
+    monkeypatch.setenv("MAGIC_LINK_SECRET", "")
+    get_settings.cache_clear()
+    with pytest.raises(MagicLinkConfigError):
+        verify_magic_link(token)
+
+
+def test_token_with_wrong_salt_raises_invalid() -> None:
+    # The auth module signs with salt="magic-link". A token signed with
+    # a different salt under the same secret must NOT be accepted —
+    # this is the salt's whole job.
+    secret = _TEST_SECRET
+    other_serializer = URLSafeTimedSerializer(secret, salt="some-other-purpose")
+    foreign_token = other_serializer.dumps({"email": "a@b.com", "nonce": "n1"})
+
+    with pytest.raises(MagicLinkInvalid):
+        verify_magic_link(foreign_token)
+
+
+def test_malformed_payload_raises_invalid() -> None:
+    # A correctly signed payload that doesn't look like {email, nonce}
+    # must raise — we don't want None-return surprises in callers.
+    secret = _TEST_SECRET
+    serializer = URLSafeTimedSerializer(secret, salt="magic-link")
+    bad_payload_token = serializer.dumps("just a string, not a dict")
+    with pytest.raises(MagicLinkInvalid):
+        verify_magic_link(bad_payload_token)
+
+    missing_field_token = serializer.dumps({"email": "a@b.com"})  # no nonce
+    with pytest.raises(MagicLinkInvalid):
+        verify_magic_link(missing_field_token)
+
+
+def test_two_tokens_with_different_nonces_decode_to_their_own_nonces() -> None:
+    # Sanity check that nonce isn't a constant baked in somewhere.
+    t1 = sign_magic_link("a@b.com", "first")
+    t2 = sign_magic_link("a@b.com", "second")
+    assert t1 != t2
+    assert verify_magic_link(t1)[1] == "first"
+    assert verify_magic_link(t2)[1] == "second"

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "alembic" },
     { name = "fastapi" },
+    { name = "itsdangerous" },
     { name = "jinja2" },
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pydantic-settings" },
@@ -32,6 +33,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28" },
+    { name = "itsdangerous", specifier = ">=2.2" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2" },
@@ -342,6 +344,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Ticket

Closes #4

## Summary

The pure-function token module that the magic-link auth flow (#6) will use. No DB, no HTTP, no logging of token contents — sign and verify operate on a `(email, nonce)` tuple via `itsdangerous.URLSafeTimedSerializer`. Three typed exceptions; never returns `None` on failure.

## Changes Made

- `app/auth/tokens.py` — `sign_magic_link(email, nonce)` and `verify_magic_link(token)`. Hard-coded 15-minute TTL, salt `"magic-link"`. Exceptions: `MagicLinkInvalid`, `MagicLinkExpired`, `MagicLinkConfigError`
- `app/auth/__init__.py` — module placeholder; routes / `current_user` / email integration arrive in #5 and #6
- `app/config.py` — `magic_link_secret: SecretStr = SecretStr("")` (empty default keeps existing dev/test code paths cheap; the auth code raises explicitly on first use if it's still empty)
- `pyproject.toml` — `itsdangerous>=2.2` added to runtime deps
- `.env.example` — new file documenting the four currently-defined env vars
- `.gitignore` — whitelist `.env.example` so the framework's `.env.*` rule doesn't exclude it

## Notable design choices

- **Empty default for `MAGIC_LINK_SECRET`** matches the existing `database_url` + `_refuse_sqlite_outside_dev` pattern: cheap construction in dev, loud failure in production. Strict reading of the ticket guardrail ("never fall back to a default") would mean no default at all and require every test that touches `Settings()` to set the env var. The chosen path validates lazily at call time, so the failure mode the guardrail cares about (signing without a secret) still raises a clear, typed error
- **Salt is hard-coded** (`"magic-link"`) — the ticket spec, and centralizing it in this module keeps callers from inventing their own
- **Module-private `_serializer()`** so the secret + salt + TTL never leak as a configurable surface
- **`verify_magic_link` validates payload shape** (must be `dict` with `email` and `nonce` keys) — guards against future callers who might serialize different things under the same secret + salt

## Testing

### Five DoD assertions (all in `tests/auth/test_tokens.py`)

- [x] `verify(sign(...))` round-trips `(email, nonce)`
- [x] One-byte mutation raises `MagicLinkInvalid`
- [x] Token signed with a different secret raises `MagicLinkInvalid`
- [x] Token older than 900s raises `MagicLinkExpired` (uses `monkeypatch` on `time.time` — no real sleep)
- [x] Empty `MAGIC_LINK_SECRET` env var causes `sign_magic_link` to raise `MagicLinkConfigError`

### Belt-and-suspenders cases

- [x] Verify with empty secret also raises (don't leak signing without verifying ability)
- [x] Token signed with same secret but different salt is rejected
- [x] Correctly signed but malformed payload (string instead of dict, missing `nonce`) raises invalid
- [x] Two tokens with different nonces decode to their own nonces (sanity check that nonce isn't a constant)

### Local checks

- [x] `uv run ruff check .` — zero errors
- [x] `uv run mypy app/` — zero errors (15 source files)
- [x] `uv run pytest` — **38 passed**
- [x] Coverage: 96% overall, **100% on `app/auth/tokens.py`** and `app/config.py`

## Reviewer checklist

- [ ] `grep -R 'import anthropic\\|from anthropic' app/` returns nothing yet (boundary respected — Anthropic ticket is #8)
- [ ] `grep -R 'MAGIC_LINK_SECRET' app/` returns exactly one read site (`app/config.py` line 24)
- [ ] No `print` / `logger.info` calls leak the token or secret (just `grep -R 'magic_link\\|MAGIC_LINK' app/` and inspect each)
- [ ] `itsdangerous` is the only new runtime dep
- [ ] `cp .env.example .env` and set a real `MAGIC_LINK_SECRET` — `uv run python -c "from app.auth.tokens import sign_magic_link, verify_magic_link; t = sign_magic_link('a@b.com', 'n1'); print(verify_magic_link(t))"` returns `('a@b.com', 'n1')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)