### PR TITLE
feat(auth): current_user + optional_user FastAPI dependencies

### DIFF
--- a/app/auth/deps.py
+++ b/app/auth/deps.py
@@ -1,0 +1,69 @@
+"""FastAPI dependencies for resolving the current user from a session cookie.
+
+`current_user` raises `HTTPException(401)` for any unauthenticated state —
+no cookie, garbage cookie, no matching session row, or expired session.
+Route handlers wanting redirect-on-missing must catch this themselves;
+the dependency is deliberately strict.
+
+`optional_user` returns `None` for the same set of failure modes — for
+public routes that *might* personalize when a session is present.
+
+Both filter by `Session.expires_at > now()` at the SQL level so an
+expired row is invalid even if it still exists in the database; we
+deliberately do NOT mutate session state in the dependency (no sliding
+expiration in v1 — see ticket #5 guardrails).
+"""
+
+from datetime import UTC, datetime
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import Depends, HTTPException, Request, status
+from sqlmodel import Session as DBSession
+from sqlmodel import col, select
+
+from app.config import Settings
+from app.db import get_session
+from app.models.session import Session as UserSession
+from app.models.user import User
+
+DBSessionDep = Annotated[DBSession, Depends(get_session)]
+
+
+def _resolve_user(request: Request, db: DBSession) -> User | None:
+    """Pure resolution: cookie → User instance, or None for any failure."""
+    raw_cookie = request.cookies.get(Settings.SESSION_COOKIE_NAME)
+    if not raw_cookie:
+        return None
+
+    try:
+        session_id = UUID(raw_cookie)
+    except ValueError:
+        return None
+
+    statement = (
+        select(User)
+        .join(UserSession, col(UserSession.user_id) == col(User.id))
+        .where(
+            col(UserSession.id) == session_id,
+            col(UserSession.expires_at) > datetime.now(UTC),
+        )
+    )
+    return db.exec(statement).first()
+
+
+def current_user(request: Request, db: DBSessionDep) -> User:
+    """Require an authenticated user, or raise 401."""
+    user = _resolve_user(request, db)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Session"},
+        )
+    return user
+
+
+def optional_user(request: Request, db: DBSessionDep) -> User | None:
+    """Return the authenticated user if any, else None — never raises."""
+    return _resolve_user(request, db)

--- a/app/config.py
+++ b/app/config.py
@@ -6,7 +6,7 @@ or Cloud Run Secret Manager mounts.
 """
 
 from functools import lru_cache
-from typing import Self
+from typing import ClassVar, Self
 
 from pydantic import SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -23,6 +23,12 @@ class Settings(BaseSettings):
     # the auth code raises explicitly if it's empty at call time. See
     # app/auth/tokens.py.
     magic_link_secret: SecretStr = SecretStr("")
+
+    # Session-cookie + TTL constants. ClassVar so pydantic-settings does
+    # NOT treat them as env-overridable — the cookie name is part of the
+    # auth contract and must not differ between environments.
+    SESSION_COOKIE_NAME: ClassVar[str] = "session_id"
+    SESSION_TTL_DAYS: ClassVar[int] = 30
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/tests/auth/test_deps.py
+++ b/tests/auth/test_deps.py
@@ -1,0 +1,191 @@
+"""Tests for the current_user / optional_user FastAPI dependencies.
+
+The five DoD assertions from issue #5:
+
+  1. Route protected with `Depends(current_user)` returns 401 when no
+     cookie is present.
+  2. Same returns 401 when the cookie value doesn't match any Session.
+  3. Same returns 401 when the Session row exists but expires_at < now().
+  4. Same returns the correct User to the handler when the cookie maps
+     to a valid, unexpired Session.
+  5. `optional_user` returns None (not raises) when no cookie is present.
+
+Extra coverage: WWW-Authenticate header on 401, garbage-UUID cookie,
+and optional_user happy path.
+"""
+
+from collections.abc import Generator
+from datetime import UTC, datetime, timedelta
+from typing import Annotated
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from app.auth.deps import current_user, optional_user
+from app.db import get_session
+from app.models.session import Session as UserSession
+from app.models.user import User
+
+
+@pytest.fixture(name="db_session")
+def db_session_fixture() -> Generator[Session, None, None]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+
+@pytest.fixture(name="client")
+def client_fixture(db_session: Session) -> Generator[TestClient, None, None]:
+    """A throwaway FastAPI app with two routes that exercise the deps.
+
+    /whoami     — Depends(current_user); 401 on auth failure
+    /maybe      — Depends(optional_user); always 200 with user-or-null
+    """
+    test_app = FastAPI()
+
+    def get_session_override() -> Generator[Session, None, None]:
+        yield db_session
+
+    test_app.dependency_overrides[get_session] = get_session_override
+
+    @test_app.get("/whoami")
+    def whoami(user: Annotated[User, Depends(current_user)]) -> dict[str, str]:
+        return {"id": str(user.id), "email": user.email}
+
+    @test_app.get("/maybe")
+    def maybe(
+        user: Annotated[User | None, Depends(optional_user)],
+    ) -> dict[str, str | None]:
+        return {"id": str(user.id) if user else None}
+
+    with TestClient(test_app) as c:
+        yield c
+
+
+def _make_user_with_session(
+    db_session: Session,
+    *,
+    email: str = "alice@example.com",
+    expires_in: timedelta = timedelta(days=30),
+) -> tuple[User, UserSession]:
+    user = User(email=email)
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    sess = UserSession(
+        user_id=user.id,
+        expires_at=datetime.now(UTC) + expires_in,
+    )
+    db_session.add(sess)
+    db_session.commit()
+    db_session.refresh(sess)
+    return user, sess
+
+
+def test_current_user_returns_401_when_no_cookie(client: TestClient) -> None:
+    response = client.get("/whoami")
+    assert response.status_code == 401
+    # Project guardrail: 401s must carry WWW-Authenticate so clients know
+    # which auth scheme is in play.
+    assert response.headers.get("www-authenticate") == "Session"
+
+
+def test_current_user_returns_401_when_cookie_does_not_match_any_session(
+    client: TestClient,
+) -> None:
+    bogus_id = uuid4()
+    client.cookies.set("session_id", str(bogus_id))
+    response = client.get("/whoami")
+    assert response.status_code == 401
+
+
+def test_current_user_returns_401_when_session_is_expired(
+    client: TestClient, db_session: Session
+) -> None:
+    _user, sess = _make_user_with_session(
+        db_session,
+        email="expired@example.com",
+        # Negative delta — already expired
+        expires_in=timedelta(seconds=-1),
+    )
+    client.cookies.set("session_id", str(sess.id))
+    response = client.get("/whoami")
+    assert response.status_code == 401
+
+
+def test_current_user_returns_the_user_for_a_valid_session(
+    client: TestClient, db_session: Session
+) -> None:
+    user, sess = _make_user_with_session(db_session, email="valid@example.com")
+    client.cookies.set("session_id", str(sess.id))
+    response = client.get("/whoami")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["email"] == "valid@example.com"
+    assert UUID(body["id"]) == user.id
+
+
+def test_optional_user_returns_none_when_no_cookie(client: TestClient) -> None:
+    response = client.get("/maybe")
+    assert response.status_code == 200
+    assert response.json() == {"id": None}
+
+
+def test_optional_user_returns_user_when_session_is_valid(
+    client: TestClient, db_session: Session
+) -> None:
+    user, sess = _make_user_with_session(db_session, email="opt@example.com")
+    client.cookies.set("session_id", str(sess.id))
+    response = client.get("/maybe")
+    assert response.status_code == 200
+    assert response.json() == {"id": str(user.id)}
+
+
+def test_optional_user_returns_none_for_expired_session(
+    client: TestClient, db_session: Session
+) -> None:
+    _user, sess = _make_user_with_session(
+        db_session, email="opt-exp@example.com", expires_in=timedelta(seconds=-1)
+    )
+    client.cookies.set("session_id", str(sess.id))
+    response = client.get("/maybe")
+    assert response.status_code == 200
+    assert response.json() == {"id": None}
+
+
+def test_garbage_uuid_in_cookie_is_treated_as_unauthenticated(
+    client: TestClient,
+) -> None:
+    # The UUID parse failure must not leak as a 500 — same 401 path as
+    # any other unauthenticated state.
+    client.cookies.set("session_id", "not-a-uuid")
+    response = client.get("/whoami")
+    assert response.status_code == 401
+
+    response = client.get("/maybe")
+    assert response.status_code == 200
+    assert response.json() == {"id": None}
+
+
+def test_session_lookup_does_not_modify_session_row(
+    client: TestClient, db_session: Session
+) -> None:
+    """No sliding expiration in v1 — verifying expires_at is unchanged after lookup."""
+    _user, sess = _make_user_with_session(db_session, email="static@example.com")
+    original_expires_at = sess.expires_at
+
+    client.cookies.set("session_id", str(sess.id))
+    client.get("/whoami")
+
+    db_session.refresh(sess)
+    assert sess.expires_at == original_expires_at


### PR DESCRIPTION
## Ticket

Closes #5

## Summary

Adds the FastAPI dependency layer that turns a `session_id` cookie into a `User` instance. Routes use `Depends(current_user)` to require auth (401 on any failure) or `Depends(optional_user)` to optionally personalize. This is the missing piece that unblocks #6 (auth routes), #7 (projects CRUD), #8 (character generation), and #9 (sheet view) — every authenticated route in the app will pull the user via this dependency.

## Changes Made

- `app/auth/deps.py`:
  - `_resolve_user(request, db)` — pure cookie → User-or-None resolver. Single `SELECT User JOIN Session WHERE Session.id = uuid AND Session.expires_at > now()` query
  - `current_user(request, db)` — raises `HTTPException(401)` with `WWW-Authenticate: Session` header on failure
  - `optional_user(request, db)` — returns `None` on failure, never raises
  - Garbage UUID in the cookie is treated as unauthenticated (not 500)
  - Deliberately does NOT mutate session state — no sliding expiration in v1
- `app/config.py`:
  - `SESSION_COOKIE_NAME: ClassVar[str] = "session_id"` — `ClassVar` so pydantic-settings won't treat it as env-overridable (the cookie name is part of the auth contract; non-configurable per ticket guardrail)
  - `SESSION_TTL_DAYS: ClassVar[int] = 30`

## Notable design choices

- **Single SELECT with JOIN** instead of two queries (Session, then User) — one round-trip, no N+1
- **`col()` wrappers** on the JOIN/WHERE expressions — needed for mypy's strict type-check-defs to recognize the SQLAlchemy operator overloads. Functionally identical to bare `==`/`>`
- **`UserSession` import alias** for `app.models.session.Session` to avoid colliding with `sqlmodel.Session` in the same file
- **No `relationship()` on the models** — kept the data-models PR scope-tight; the JOIN in deps.py is explicit instead. If we add cascading queries later we can revisit
- **`_resolve_user` is private** — the public surface is just `current_user` and `optional_user`. Future routes that need a different failure mode (e.g. redirect-on-missing) can write their own dependency on top of `optional_user`

## Testing

### Five DoD assertions (`tests/auth/test_deps.py`)

- [x] `Depends(current_user)` → 401 when no cookie present
- [x] `Depends(current_user)` → 401 when cookie value doesn't match any `Session`
- [x] `Depends(current_user)` → 401 when `Session.expires_at` is in the past
- [x] `Depends(current_user)` → 200 with the correct `User` for a valid, unexpired Session
- [x] `Depends(optional_user)` → returns `None` (does not raise) when no cookie

### Belt-and-suspenders cases

- [x] 401 response includes `WWW-Authenticate: Session` header
- [x] Garbage UUID cookie returns 401 (not 500) on `current_user`, returns `None` on `optional_user`
- [x] `optional_user` returns the User for a valid Session (happy path)
- [x] `optional_user` returns None for an expired Session
- [x] Lookup does NOT mutate `session.expires_at` (no sliding expiration)

### Local checks

- [x] `uv run ruff check .` — zero errors
- [x] `uv run mypy app/` — zero errors (16 source files)
- [x] `uv run pytest` — **47 passed**
- [x] Coverage: 96% overall, **100% on `app/auth/deps.py`**

## Reviewer checklist

- [ ] `grep -R 'from app.models.session' app/ tests/` shows imports use the explicit `Session as UserSession` alias (avoid collision with `sqlmodel.Session`)
- [ ] `grep -R 'session_id\|SESSION_COOKIE_NAME' app/` confirms the cookie name reads from `Settings.SESSION_COOKIE_NAME` rather than being inlined
- [ ] No `app.dependency_overrides` leaking from one test fixture to another (each test gets a fresh `test_app`)
- [ ] `uv run pytest tests/auth/test_deps.py -v` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)